### PR TITLE
Add preview URLs on Pull Requests from "surge.sh"

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,26 +1,5 @@
 name: 🔂 Surge PR Preview
 
-on: [pull_request]
-
-jobs:
-  preview:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: afc163/surge-preview@v1
-        id: preview_step
-        with:
-          surge_token: ${{ secrets.SURGE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: public
-          build: |
-            npm install
-            npm run build
-      - name: Get the preview_url
-        run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"
-
-name: 🔂 Surge PR Preview
-
 on:
   pull_request:
     # when using teardown: 'true', add default event types + closed event type

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: public
+          dist: dist
           teardown: 'true'
           build: |
-            npm install
-            npm run build
+            yarn install --frozen-lockfile
+            yarn generate
       - name: Get the preview_url
         run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,45 @@
+name: 🔂 Surge PR Preview
+
+on: [pull_request]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: afc163/surge-preview@v1
+        id: preview_step
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: public
+          build: |
+            npm install
+            npm run build
+      - name: Get the preview_url
+        run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"
+
+name: 🔂 Surge PR Preview
+
+on:
+  pull_request:
+    # when using teardown: 'true', add default event types + closed event type
+    types: [opened, synchronize, reopened, closed]
+  push:
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: afc163/surge-preview@v1
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: public
+          teardown: 'true'
+          build: |
+            npm install
+            npm run build
+      - name: Get the preview_url
+        run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "nuxt",
     "build": "nuxt build",
     "start": "nuxt start",
-    "generate": "nuxt generate"
+    "generate": "nuxt generate",
+    "test": "echo \"Error: no test specified.\""
   },
   "dependencies": {
     "@nuxt/content-theme-docs": "^0.6.0",


### PR DESCRIPTION
# What does this PR do
* This adds the Github Action that will build preview URLs for the documentation

# Example
See how this works on this example pull request: https://github.com/jaydrogers/docs/pull/2
<a href="https://github.com/jaydrogers/docs/pull/2"><img width="942" alt="image" src="https://user-images.githubusercontent.com/3174134/127895659-b3e03288-08ef-4ab7-a87b-c42b30e2f0cf.png"></a>

# More information
* Here is the Github Action that is added: https://github.com/marketplace/actions/surge-pr-preview

# TODO before merging
A `surge_token` needs to be create for this to work. To do this, you will need to do this on your local machine:

- [ ] Install Surge on your computer (`npm install --global surge`)
- [ ] Create an account from the CLI (`surge login`)
- [ ] Create your account (follow the prompts)
- [ ] Generate a token (`surge token`)
- [ ] Add the token to Gitlab Secrets (variable is: `surge_token`) 