### PR TITLE
Instruct to add MX to rp instead of A/AAAA

### DIFF
--- a/content/en/install/dns-configuration.md
+++ b/content/en/install/dns-configuration.md
@@ -78,13 +78,8 @@ The return path domain is the default domain that is used as the `MAIL FROM` for
   <tbody>
     <tr>
       <td>rp.postal.example.com</td>
-      <td>A</td>
-      <td><code>192.168.1.3</code></td>
-    </tr>
-    <tr>
-      <td>rp.postal.example.com</td>
-      <td>AAAA</td>
-      <td><code>2a00:1234:abcd:1::3</code></td>
+      <td>MX</td>
+      <td><code>10 postal.example.com</code></td>
     </tr>
     <tr>
       <td>rp.postal.example.com</td>


### PR DESCRIPTION
Not sure why we should add a A/AAAA to the rp, and forget the MX. :)