### PR TITLE
Update spam-and-virus-checking.md

### DIFF
--- a/content/en/features/spam-and-virus-checking.md
+++ b/content/en/features/spam-and-virus-checking.md
@@ -20,7 +20,11 @@ By default, Postal will talk to SpamAssassin's `spamd` using an TCP socket conne
 sudo apt install spamassassin
 ```
 
-Once you have installed this, you will need to open up `/etc/default/spamassassin` and change `ENABLED` to `1` and  `CRON` to `1`. Then you should restart SpamAssassin.
+Once you have installed this, you will need to open up `/etc/default/spamassassin` and change `ENABLED` to `1` and  `CRON` to `1`. On some systems (such as Ubuntu 20 or newer), you might need to enable the SpamAssassin daemon with the following command.
+```
+update-rc.d spamassassin enable
+```
+Then you should restart SpamAssassin.
 
 ```
 sudo systemctl restart spamassassin


### PR DESCRIPTION
Systems with spamassassin 3.4.2-1 or newer don't support "ENABLED=1" anymore; instead you need to do update-rc.d. This is documented in a comment in /etc/default/spamassassin.