### PR TITLE
Fix prerequisites link

### DIFF
--- a/content/en/install/installation.md
+++ b/content/en/install/installation.md
@@ -5,7 +5,7 @@ position: 2.1
 category: Installation
 ---
 
-Once you've completed all the [prerequisites](./prerequisites), you can go ahead and start to install Postal.
+Once you've completed all the [prerequisites](../prerequisites), you can go ahead and start to install Postal.
 
 ## Configuration
 


### PR DESCRIPTION
Because URLs are structured like directories, relative links in the "same" folder need to use `../`