### PR TITLE
Set Node version to 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   node:
-    image: node:lts
+    image: node:16
     command: "yarn dev"
     environment:
       HOST: 0.0.0.0


### PR DESCRIPTION
# Problem
- The node version was set to `lts`, which originally was `16` for this project, but now has automatically moved to `18`
- This broke a fresh install with Docker (screenshot below)

<img width="829" alt="Screenshot 2023-02-01 at 14 29 50" src="https://user-images.githubusercontent.com/3174134/216160266-392b9563-3949-4b28-829c-fb4fd6f31929.png">

# What this PR does
- This changes the Node version from `lts` to `16` (which is compatible with the Node libraries required)