### PR TITLE
Fix broken Prerequisites link

### DIFF
--- a/content/en/install/installation.md
+++ b/content/en/install/installation.md
@@ -5,7 +5,7 @@ position: 2.1
 category: Installation
 ---
 
-Once you've completed all the [prerequisites](./prerequisites), you can go ahead and start to install Postal.
+Once you've completed all the <a href="/install/prerequisites">prerequisites</a>, you can go ahead and start to install Postal.
 
 ## Configuration
 


### PR DESCRIPTION
When the page url is 
https://docs.postalserver.io/install/installation/ the link to the Prerequisites page is broken.

Use the same link style as here: 
https://github.com/postalserver/docs/edit/main/content/en/install/upgrading.md