### PR TITLE
Add link to new client library .net core

### DIFF
--- a/content/4.developer/2.client-libraries.md
+++ b/content/4.developer/2.client-libraries.md
@@ -13,6 +13,7 @@ There are a number of client libraries available to help send e-mail using the P
 * [Node](https://github.com/postalserver/postal-node)
 * [Java](https://github.com/matthewmgamble/postal-java)
 * [.Net](https://github.com/KingdomFirst/PostalServer-DotNet-Framework)
+* [.NET Core](https://github.com/mDev86/PostalApiClient)
 * [Go](https://github.com/Pacerino/postal-go)
 
 


### PR DESCRIPTION
I am wrote new library (api client) for .NET Core. Add link in docs, please