### PR TITLE
Added more details on SMTP authentication

### DIFF
--- a/content/3.features/smtp-authentication.md
+++ b/content/3.features/smtp-authentication.md
@@ -11,8 +11,31 @@ For sending outgoing emails through the Postal SMTP server you will need to gene
 When authenticating to the SMTP server, there are three supported authentication types.
 
 * `PLAIN` - the credentials are passed in plain text to the server. When using this, you can provide any string as the username (e.g. `x`) and the password should contain your credential string.
-* `LOGIN` - the credentials are passed Base64-encoded to the server. As above, you can use anything as the username and the password should contain the credential string (Base64-encoded).
+* `LOGIN` - the credentials are passed Base64-encoded to the server. As above, you can use anything as the username and the password should contain the credential string (Base64-encoded). Check the example below:
+  ```
+  # Example snippet:
+  # Let's assume, you use "$ telnet <smtp_server_ip_address> 25"
+  Trying <smtp_server_ip_address>
+  Connected to <smtp_server_ip_address>
+  Escape character is '^]'.
+  220 postal.example.com ESMTP Postal/GWLMYC7F
+
+  # You start from here:
+  HELO example.com
+  250 postal.example.com
+  AUTH LOGIN
+  334 VXNlcm5hbWU6
+  c29tLXNtdHAtdXNlcg==             >> you would need to enter any or your smtp username in base64 - try command - "echo -n 'your-username' | base64"
+  334 UGFzc3dvcmQ6
+  OElLM0Q4ckFOQW9obTl0QnpQcVpkRlhi >> you would need to enter your smtp key generated in the web UI in base64 - try command - "echo -n '8IK3D8rXXNAohm9tBzPqZdFXb' | base64"
+  235 Granted for <organization-name>/<mail-server>
+  ```
 * `CRAM-MD5` - this is a challenge-response mechanism based on the HMAC-MD5 algorithm. Unlike the above two mechanism, the username does matter and should contain the organization and server permalinks separated by a `/` or `_` character. The password used should be the value from your credential.
+
+To get the `Credentials`, you can go to the Postal home > Credentials > Click or Add a Credential > Copy the username and the generated key.
+
+![smtp_credentials](https://github.com/user-attachments/assets/be0bf380-b369-49d8-83b5-e824561e0c15)
+
 
 ## From/Sender validation
 


### PR DESCRIPTION
Team, I was trying to improvise the documentation while I try to work on the postal server. Added an example snippet to support the SMTP authentication and correlated it with demo screenshot from the server itself.