### PR TITLE
Add Elixir language to the list of client libraries

### DIFF
--- a/content/4.developer/2.client-libraries.md
+++ b/content/4.developer/2.client-libraries.md
@@ -15,7 +15,7 @@ There are a number of client libraries available to help send e-mail using the P
 * [.Net](https://github.com/KingdomFirst/PostalServer-DotNet-Framework)
 * [.NET Core](https://github.com/mDev86/PostalApiClient)
 * [Go](https://github.com/Pacerino/postal-go)
-
+* [Elixir (via Swoosh)](https://hexdocs.pm/swoosh/Swoosh.Adapters.Postal.html)
 
 All of these libraries will make use of the API rather than using any SMTP protocol - this is considered to be best approach for delivering your messages.
 


### PR DESCRIPTION
I'm happy to announce that I have recently implemented a Postal adapter for Swoosh, which is "go-to" high-level mailing library in Elixir ecosystem. My contribution was released in Swoosh v1.17.

This means there is now an integration for Elixir language, so I have extended the list of client side libraries in this PR.

You can see my [pull request to Swoosh](https://github.com/swoosh/swoosh/pull/949) for reference.
