### PR TITLE
fix(spam-check): describe install with systemd

### DIFF
--- a/content/3.features/spam-and-virus-checking.md
+++ b/content/3.features/spam-and-virus-checking.md
@@ -19,7 +19,14 @@ By default, Postal will talk to SpamAssassin's `spamd` using an TCP socket conne
 sudo apt install spamassassin
 ```
 
-Once you have installed this, you will need to open up `/etc/default/spamassassin` and change `ENABLED` to `1` and  `CRON` to `1`. On some systems (such as Ubuntu 20.04 or newer), you might need to enable the SpamAssassin daemon with the following command.
+#### Systemd systems
+On systems that use systemd (e.g. Debian Bookworm), you will need to enable the SpamAssassin timer. It is used to udpate the spam rules (which can be done manually using `sa-update`).
+
+```shell
+systemctl enable --now spamassassin-maintenance.timer
+```
+#### Other systems
+On other systems, you will need to open up `/etc/default/spamassassin` and change `ENABLED` to `1` and  `CRON` to `1`. On some systems (such as Ubuntu 20.04 or newer), you might need to enable the SpamAssassin daemon with the following command.
 
 ```bash
 update-rc.d spamassassin enable 

--- a/content/3.features/spam-and-virus-checking.md
+++ b/content/3.features/spam-and-virus-checking.md
@@ -25,6 +25,7 @@ On systems that use systemd (e.g. Debian Bookworm), you will need to enable the 
 ```shell
 systemctl enable --now spamassassin-maintenance.timer
 ```
+
 #### Other systems
 On other systems, you will need to open up `/etc/default/spamassassin` and change `ENABLED` to `1` and  `CRON` to `1`. On some systems (such as Ubuntu 20.04 or newer), you might need to enable the SpamAssassin daemon with the following command.
 


### PR DESCRIPTION
Spamassassin on debian does not ship a /etc/default/spamassassin file, so enabling the update task needs to be done using systemctl.