### PR TITLE
Fix size of the RSA key in bits

### DIFF
--- a/content/5.other/2.containers.md
+++ b/content/5.other/2.containers.md
@@ -49,7 +49,7 @@ The image expects all configuration to be mounted at `/config`. At a minimum, th
 The `signing.key` can be generated using the following command:
 
 ```
-openssl genrsa -out path/to/signing.key 2018
+openssl genrsa -out path/to/signing.key 2048
 ```
 
 ## Networking


### PR DESCRIPTION
2018-bit key is an unusual size and does not follow standard key length recommendations.