### PR TITLE
Added how to use Caddy Certificate for Postal

### DIFF
--- a/content/3.features/smtp-tls.md
+++ b/content/3.features/smtp-tls.md
@@ -72,7 +72,7 @@ while true; do
     chmod o+r /opt/postal/config/smtp.*
 
     # Restart Postal to use the new certificates
-    postal stop && sleep 15 && postal start
+    postal restart
 done
 ```
 
@@ -114,8 +114,8 @@ sudo systemctl start monitor_certs.service
 ##### Initial Manual Certificate Copy
 Before the monitoring script takes over, you should manually copy the certificates for the first time:
 ```bash
-cp /opt/postal/caddy-data/caddy/certificates/acme.zerossl.com-v2-dv90/YOURDOMAIN/YOURDOMAIN.crt /opt/postal/config/smtp.cert
-cp /opt/postal/caddy-data/caddy/certificates/acme.zerossl.com-v2-dv90/YOURDOMAIN/YOURDOMAIN.key /opt/postal/config/smtp.key
+cp /opt/postal/caddy-data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/YOURDOMAIN/YOURDOMAIN.crt /opt/postal/config/smtp.cert
+cp /opt/postal/caddy-data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/YOURDOMAIN/YOURDOMAIN.key /opt/postal/config/smtp.key
 chmod o+r /opt/postal/config/smtp.*
 ```
 

--- a/content/3.features/smtp-tls.md
+++ b/content/3.features/smtp-tls.md
@@ -21,6 +21,104 @@ You can use the command below to generate a self-signed certificate.
 openssl req -x509 -newkey rsa:4096 -keyout /opt/postal/config/smtp.key -out /opt/postal/config/smtp.cert -sha256 -days 365 -nodes
 ```
 
+### Using Caddy certificate for TLS
+
+#### Setting up Caddy to issue RSA certificate
+
+Caddy doesn't issue RSA certificates by default, so first we have to setup caddy to issue RSA certificate. This is done by adding following lines to the start of `/opt/postal/config/Caddyfile`:
+```yaml
+# Force Caddy to generate RSA certificates
+# https://github.com/postalserver/postal/discussions/1572#discussioncomment-1410343
+{
+  key_type rsa4096
+}
+```
+
+#### Setup automatic copying from Caddy to Postal
+
+To remove the need of the manual mainenance task to copy the certificate from Caddy to Postal we can automate this. The original discussion and author can be found [here](https://github.com/orgs/postalserver/discussions/2673).
+
+##### Install inotify-tools
+
+Install the toolset which provides `inotifywait`, used to monitor certificate changes.
+
+```bash
+sudo apt-get update
+sudo apt-get install inotify-tools
+```
+
+##### Create Monitoring Script
+
+Create a script named `monitor_certs.sh`:
+```bash
+nano /opt/postal/monitor_certs.sh
+```
+Add following code to the script file:
+```bash
+#!/bin/bash
+
+CERT_DIR="/opt/postal/caddy-data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/YOURDOMAIN/"
+CERT_FILE="${CERT_DIR}YOURDOMAIN.crt"
+KEY_FILE="${CERT_DIR}YOURDOMAIN.key"
+
+while true; do
+    inotifywait -e modify "$CERT_FILE" "$KEY_FILE"
+
+    # Copy the certificates to Postal's configuration directory
+    cp "$CERT_FILE" /opt/postal/config/smtp.cert
+    cp "$KEY_FILE" /opt/postal/config/smtp.key
+
+    # Adjust permissions to ensure Postal can read the certificates
+    chmod o+r /opt/postal/config/smtp.*
+
+    # Restart Postal to use the new certificates
+    postal stop && sleep 15 && postal start
+done
+```
+
+Make the script executable:
+```bash
+chmod +x /opt/postal/monitor_certs.sh
+```
+##### Create a systemd Service
+
+Make a systemd service file:
+```bash
+sudo nano /etc/systemd/system/monitor_certs.service
+```
+Insert the following content:
+```yaml
+[Unit]
+Description=Monitor Caddy Certificates for Postal
+
+[Service]
+ExecStart=/opt/postal/monitor_certs.sh
+Restart=always
+User=your_username 
+Group=your_groupname
+
+[Install]
+WantedBy=multi-user.target
+```
+
+##### Activate the Service
+Reload the systemd daemons:
+```bash
+sudo systemctl daemon-reload
+```
+Enable and start the service:
+```bash
+sudo systemctl enable monitor_certs.service
+sudo systemctl start monitor_certs.service
+```
+##### Initial Manual Certificate Copy
+Before the monitoring script takes over, you should manually copy the certificates for the first time:
+```bash
+cp /opt/postal/caddy-data/caddy/certificates/acme.zerossl.com-v2-dv90/YOURDOMAIN/YOURDOMAIN.crt /opt/postal/config/smtp.cert
+cp /opt/postal/caddy-data/caddy/certificates/acme.zerossl.com-v2-dv90/YOURDOMAIN/YOURDOMAIN.key /opt/postal/config/smtp.key
+chmod o+r /opt/postal/config/smtp.*
+```
+
 ## Configuration
 
 Once you have a key and certificate you will need to enable TLS in the configuration file (`/opt/postal/config/postal.yml`). Additional options are available too.

--- a/content/3.features/smtp-tls.md
+++ b/content/3.features/smtp-tls.md
@@ -23,17 +23,6 @@ openssl req -x509 -newkey rsa:4096 -keyout /opt/postal/config/smtp.key -out /opt
 
 ### Using Caddy certificate for TLS
 
-#### Setting up Caddy to issue RSA certificate
-
-Caddy doesn't issue RSA certificates by default, so first we have to setup caddy to issue RSA certificate. This is done by adding following lines to the start of `/opt/postal/config/Caddyfile`:
-```yaml
-# Force Caddy to generate RSA certificates
-# https://github.com/postalserver/postal/discussions/1572#discussioncomment-1410343
-{
-  key_type rsa4096
-}
-```
-
 #### Setup automatic copying from Caddy to Postal
 
 To remove the need of the manual mainenance task to copy the certificate from Caddy to Postal we can automate this. The original discussion and author can be found [here](https://github.com/orgs/postalserver/discussions/2673).

--- a/content/3.features/smtp-tls.md
+++ b/content/3.features/smtp-tls.md
@@ -25,7 +25,7 @@ openssl req -x509 -newkey rsa:4096 -keyout /opt/postal/config/smtp.key -out /opt
 
 #### Setup automatic copying from Caddy to Postal
 
-To remove the need of the manual mainenance task to copy the certificate from Caddy to Postal we can automate this. The original discussion and author can be found [here](https://github.com/orgs/postalserver/discussions/2673).
+To remove the need of the manual maintenance task to copy the certificate from Caddy to Postal, we can automate this. The original discussion and author can be found [here](https://github.com/orgs/postalserver/discussions/2673).
 
 ##### Install inotify-tools
 
@@ -39,10 +39,13 @@ sudo apt-get install inotify-tools
 ##### Create Monitoring Script
 
 Create a script named `monitor_certs.sh`:
+
 ```bash
 nano /opt/postal/monitor_certs.sh
 ```
+
 Add following code to the script file:
+
 ```bash
 #!/bin/bash
 
@@ -69,13 +72,17 @@ Make the script executable:
 ```bash
 chmod +x /opt/postal/monitor_certs.sh
 ```
+
 ##### Create a systemd Service
 
 Make a systemd service file:
+
 ```bash
 sudo nano /etc/systemd/system/monitor_certs.service
 ```
+
 Insert the following content:
+
 ```yaml
 [Unit]
 Description=Monitor Caddy Certificates for Postal
@@ -91,17 +98,24 @@ WantedBy=multi-user.target
 ```
 
 ##### Activate the Service
+
 Reload the systemd daemons:
+
 ```bash
 sudo systemctl daemon-reload
 ```
+
 Enable and start the service:
+
 ```bash
 sudo systemctl enable monitor_certs.service
 sudo systemctl start monitor_certs.service
 ```
+
 ##### Initial Manual Certificate Copy
+
 Before the monitoring script takes over, you should manually copy the certificates for the first time:
+
 ```bash
 cp /opt/postal/caddy-data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/YOURDOMAIN/YOURDOMAIN.crt /opt/postal/config/smtp.cert
 cp /opt/postal/caddy-data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/YOURDOMAIN/YOURDOMAIN.key /opt/postal/config/smtp.key


### PR DESCRIPTION
I had to find all of this information on different discussion threads until and saw that others also didn't find it. Therefor i added it to the official documentation.

sources:
https://github.com/orgs/postalserver/discussions/1572
https://github.com/orgs/postalserver/discussions/2673