### PR TITLE
Add A and AAAA records for rp.postal.example.com

### DIFF
--- a/content/2.getting-started/4.dns-configuration.md
+++ b/content/2.getting-started/4.dns-configuration.md
@@ -112,6 +112,16 @@ The return path domain is the default domain that is used as the `MAIL FROM` for
   <tbody>
     <tr>
       <td>rp.postal.example.com</td>
+      <td>A</td>
+      <td><code>192.168.1.3</code></td>
+    </tr>
+    <tr>
+      <td>rp.postal.example.com</td>
+      <td>AAAA</td>
+      <td><code>2a00:1234:abcd:1::3</code></td>
+    </tr>
+    <tr>
+      <td>rp.postal.example.com</td>
       <td>MX</td>
       <td><code>10 postal.example.com</code></td>
     </tr>


### PR DESCRIPTION
I've been using Postal for about a month for client emails and I've noticed that a few providers can't access the `psrp` subdomain. Adding a `CNAME` or the direct `A` or `AAAA` records fixes this, so this PR adds them to the pr subdomain